### PR TITLE
Automatic IP detection with all locale

### DIFF
--- a/gravity-adv.sh
+++ b/gravity-adv.sh
@@ -4,6 +4,11 @@
 piholeIP="127.0.0.1"
 # Optionally, uncomment to automatically detect the address.  Thanks Gregg
 #piholeIP=$(ifconfig eth0 | awk '/inet addr/{print substr($2,6)}')
+# Below code allows to automatically detect the address with all locale
+langsys=$LANG
+LANG=en_US.utf8
+piholeIP=$(ifconfig eth0 | awk '/inet addr/{print substr($2,6)}')
+LANG=$langsys
 
 # Config file to hold URL rules
 eventHorizion="/etc/dnsmasq.d/adList.conf"


### PR DESCRIPTION
initial code does not work if locale is set to french 
may be also the case with other non english locale (not tested)

May be LANG saving and setting again is too much and may cause some trouble if other settings were not all same language .

pi@raspberrypi ~ $ locale
LANG=fr_FR.utf8
LANGUAGE=
LC_CTYPE="fr_FR.utf8"
LC_NUMERIC="fr_FR.utf8"
LC_TIME="fr_FR.utf8"
LC_COLLATE="fr_FR.utf8"
LC_MONETARY="fr_FR.utf8"
LC_MESSAGES="fr_FR.utf8"
LC_PAPER="fr_FR.utf8"
LC_NAME="fr_FR.utf8"
LC_ADDRESS="fr_FR.utf8"
LC_TELEPHONE="fr_FR.utf8"
LC_MEASUREMENT="fr_FR.utf8"
LC_IDENTIFICATION="fr_FR.utf8"
LC_ALL=
